### PR TITLE
cifs: use both modefromsid and idsfromsid when either one is specified

### DIFF
--- a/fs/cifs/fs_context.c
+++ b/fs/cifs/fs_context.c
@@ -1291,6 +1291,7 @@ static int smb3_fs_context_parse_param(struct fs_context *fc,
 		break;
 	case Opt_setuidfromacl:
 		ctx->setuidfromacl = 1;
+		ctx->mode_ace = 1;
 		break;
 	case Opt_strictsync:
 		ctx->nostrictsync = result.negated;
@@ -1303,6 +1304,7 @@ static int smb3_fs_context_parse_param(struct fs_context *fc,
 		break;
 	case Opt_modesid:
 		ctx->mode_ace = 1;
+		ctx->setuidfromacl = 1;
 		break;
 	case Opt_cifsacl:
 		ctx->cifs_acl = !result.negated;


### PR DESCRIPTION
Both these mount options use create sd context to create files with
certain mode or ownerships. However, all fields of an SD context need
to be specified. So there is no way for a client to indicate to the
server to set just the ownerships or just the mode bits.

Due to this, we need to implicitly select both these options, even
when one is specified.

Signed-off-by: Shyam Prasad N <sprasad@microsoft.com>