### PR TITLE
cifs: invalidate dns resolver keys after use

### DIFF
--- a/fs/cifs/dns_resolve.c
+++ b/fs/cifs/dns_resolve.c
@@ -66,7 +66,7 @@ dns_resolve_server_name_to_ip(const char *unc, char **ip_addr, time64_t *expiry)
 
 	/* Perform the upcall */
 	rc = dns_query(current->nsproxy->net_ns, NULL, hostname, len,
-		       NULL, ip_addr, expiry, false);
+		       NULL, ip_addr, expiry, true);
 	if (rc < 0)
 		cifs_dbg(FYI, "%s: unable to resolve: %*.*s\n",
 			 __func__, len, len, hostname);


### PR DESCRIPTION
We rely on dns resolver module to upcall to userspace
using request_key and get us the DNS mapping.
However, the invalidate arg for dns_query was set
to false, which meant that the key created during the
first call for a hostname would continue to be cached
till it expires. This expiration period depends on
how the dns_resolver is configured.

Fixing this by setting invalidate=true during dns_query.
This means that the key will be cleaned up by dns_resolver
soon after it returns the data. This also means that
the dns_resolver subsystem will not cache the key for
an interval indicated by the DNS records TTL. But this is
okay since we use the TTL value returned to schedule the
next lookup.

Cc: David Howells <dhowells@redhat.com>
Signed-off-by: Shyam Prasad N <sprasad@microsoft.com>