### PR TITLE
cifs: disable dns caching in kernel keyring

### DIFF
--- a/fs/cifs/dns_resolve.c
+++ b/fs/cifs/dns_resolve.c
@@ -66,7 +66,7 @@ dns_resolve_server_name_to_ip(const char *unc, char **ip_addr, time64_t *expiry)
 
 	/* Perform the upcall */
 	rc = dns_query(current->nsproxy->net_ns, NULL, hostname, len,
-		       NULL, ip_addr, expiry, false);
+		       NULL, ip_addr, expiry, true);
 	if (rc < 0)
 		cifs_dbg(FYI, "%s: unable to resolve: %*.*s\n",
 			 __func__, len, len, hostname);


### PR DESCRIPTION
While caching DNS as keys in the keyring can be beneficial,
we've seen bugs where having DNS keys cached in keyring can
result in blocking upcall to userspace.

This change disables the kernel keyring cache altogether for
dns upcalls. At a later point, we could cache in key.dns_resolver
if necessary.

Signed-off-by: Shyam Prasad N <sprasad@microsoft.com>